### PR TITLE
Add missing full and encoders-gpl artifacts 16 KB

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
 
 permissions:
   contents: write
@@ -32,17 +39,16 @@ jobs:
         run: |
           sudo chmod +x bundle_default.sh
           ./bundle_default.sh
-      # TODO(alexmercerind): Figure out this shit.
-      # - name: Bundle (full)
-      #   working-directory: ./buildscripts
-      #   run: |
-      #     sudo chmod +x bundle_full.sh
-      #     ./bundle_full.sh
-      # - name: Bundle (encoders-gpl)
-      #   working-directory: ./buildscripts
-      #   run: |
-      #     sudo chmod +x bundle_encoders-gpl.sh
-      #     ./bundle_encoders-gpl.sh
+      - name: Bundle (full)
+        working-directory: ./buildscripts
+        run: |
+          sudo chmod +x bundle_full.sh
+          ./bundle_full.sh
+      - name: Bundle (encoders-gpl)
+        working-directory: ./buildscripts
+        run: |
+          sudo chmod +x bundle_encoders-gpl.sh
+          ./bundle_encoders-gpl.sh
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
           name: artifact
           path: |
             ./buildscripts/*.jar
-            ./buildscripts/deps/media-kit-android-helper/app/build/outputs/apk/release/*.jar
+            ./buildscripts/artifacts/**
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         if: github.ref == 'refs/heads/main'
@@ -65,4 +65,4 @@ jobs:
           tag_name: "vnext"
           files: |
             buildscripts/*.zip
-            buildscripts/deps/media-kit-android-helper/app/build/outputs/apk/release/*.jar
+            buildscripts/artifacts/**

--- a/buildscripts/bundle_default.sh
+++ b/buildscripts/bundle_default.sh
@@ -50,3 +50,8 @@ zip -r default-x86.jar            lib/x86/*.so
 zip -r default-x86_64.jar         lib/x86_64/*.so
 
 md5sum *.jar
+
+cd ../../../../../../..
+
+mkdir -p artifacts/default
+cp deps/media-kit-android-helper/app/build/outputs/apk/release/default-*.jar artifacts/default/

--- a/buildscripts/bundle_encoders-gpl.sh
+++ b/buildscripts/bundle_encoders-gpl.sh
@@ -50,3 +50,8 @@ zip -r encoders-gpl-x86.jar            lib/x86/*.so
 zip -r encoders-gpl-x86_64.jar         lib/x86_64/*.so
 
 md5sum *.jar
+
+cd ../../../../../../..
+
+mkdir -p artifacts/encoders-gpl
+cp deps/media-kit-android-helper/app/build/outputs/apk/release/encoders-gpl-*.jar artifacts/encoders-gpl/

--- a/buildscripts/bundle_encoders-gpl.sh
+++ b/buildscripts/bundle_encoders-gpl.sh
@@ -21,13 +21,12 @@ cp flavors/encoders-gpl.sh scripts/ffmpeg.sh
 
 ./build.sh
 
-# --------------------------------------------------
+zip -r debug-symbols-encoders-gpl.zip prefix/*/lib
 
-# Strip debug symbols from all .so files
-llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/*.so
-llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/*.so
-llvm-strip --strip-all prefix/x86/usr/local/lib/*.so
-llvm-strip --strip-all prefix/x86_64/usr/local/lib/*.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
 
 # --------------------------------------------------
 
@@ -38,45 +37,16 @@ sudo chmod +x gradlew
 
 unzip -o app/build/outputs/apk/release/app-release.apk -d app/build/outputs/apk/release
 
-cp app/build/outputs/apk/release/lib/arm64-v8a/libmediakitandroidhelper.so      ../../prefix/arm64-v8a/usr/local/lib
-cp app/build/outputs/apk/release/lib/armeabi-v7a/libmediakitandroidhelper.so    ../../prefix/armeabi-v7a/usr/local/lib
-cp app/build/outputs/apk/release/lib/x86/libmediakitandroidhelper.so            ../../prefix/x86/usr/local/lib
-cp app/build/outputs/apk/release/lib/x86_64/libmediakitandroidhelper.so         ../../prefix/x86_64/usr/local/lib
+cp ../../prefix/arm64-v8a/usr/local/lib/libmpv.so      app/build/outputs/apk/release/lib/arm64-v8a
+cp ../../prefix/armeabi-v7a/usr/local/lib/libmpv.so    app/build/outputs/apk/release/lib/armeabi-v7a
+cp ../../prefix/x86/usr/local/lib/libmpv.so            app/build/outputs/apk/release/lib/x86
+cp ../../prefix/x86_64/usr/local/lib/libmpv.so         app/build/outputs/apk/release/lib/x86_64
 
-cd ../..
+cd app/build/outputs/apk/release
 
-mkdir -p temp/lib/arm64-v8a
-mkdir -p temp/lib/armeabi-v7a
-mkdir -p temp/lib/x86
-mkdir -p temp/lib/x86_64
-
-cp prefix/arm64-v8a/usr/local/lib/*.so temp/lib/arm64-v8a/
-cp prefix/armeabi-v7a/usr/local/lib/*.so temp/lib/armeabi-v7a/
-cp prefix/x86/usr/local/lib/*.so temp/lib/x86/
-cp prefix/x86_64/usr/local/lib/*.so temp/lib/x86_64/
-
-cd temp
-
-FIXED_TIME="2025-01-01 00:00:00"
-
-find "lib" -type d -exec touch -d "$FIXED_TIME" {} +
-find "lib/arm64-v8a" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-find "lib/armeabi-v7a" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-find "lib/x86" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-find "lib/x86_64" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-
-md5sum lib/arm64-v8a/*.so
-md5sum lib/armeabi-v7a/*.so
-md5sum lib/x86/*.so
-md5sum lib/x86_64/*.so
-
-find lib/arm64-v8a -type f | sort | zip -r -X ../encoders-gpl-arm64-v8a.jar -@
-find lib/armeabi-v7a -type f | sort | zip -r -X ../encoders-gpl-armeabi-v7a.jar -@
-find lib/x86 -type f | sort | zip -r -X ../encoders-gpl-x86.jar -@
-find lib/x86_64 -type f | sort | zip -r -X ../encoders-gpl-x86_64.jar -@
-
-cd ../
-
-pwd
+zip -r encoders-gpl-arm64-v8a.jar      lib/arm64-v8a/*.so
+zip -r encoders-gpl-armeabi-v7a.jar    lib/armeabi-v7a/*.so
+zip -r encoders-gpl-x86.jar            lib/x86/*.so
+zip -r encoders-gpl-x86_64.jar         lib/x86_64/*.so
 
 md5sum *.jar

--- a/buildscripts/bundle_full.sh
+++ b/buildscripts/bundle_full.sh
@@ -21,13 +21,12 @@ cp flavors/full.sh scripts/ffmpeg.sh
 
 ./build.sh
 
-# --------------------------------------------------
+zip -r debug-symbols-full.zip prefix/*/lib
 
-# Strip debug symbols from all .so files
-llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/*.so
-llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/*.so
-llvm-strip --strip-all prefix/x86/usr/local/lib/*.so
-llvm-strip --strip-all prefix/x86_64/usr/local/lib/*.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
 
 # --------------------------------------------------
 
@@ -38,45 +37,16 @@ sudo chmod +x gradlew
 
 unzip -o app/build/outputs/apk/release/app-release.apk -d app/build/outputs/apk/release
 
-cp app/build/outputs/apk/release/lib/arm64-v8a/libmediakitandroidhelper.so      ../../prefix/arm64-v8a/usr/local/lib
-cp app/build/outputs/apk/release/lib/armeabi-v7a/libmediakitandroidhelper.so    ../../prefix/armeabi-v7a/usr/local/lib
-cp app/build/outputs/apk/release/lib/x86/libmediakitandroidhelper.so            ../../prefix/x86/usr/local/lib
-cp app/build/outputs/apk/release/lib/x86_64/libmediakitandroidhelper.so         ../../prefix/x86_64/usr/local/lib
+cp ../../prefix/arm64-v8a/usr/local/lib/libmpv.so      app/build/outputs/apk/release/lib/arm64-v8a
+cp ../../prefix/armeabi-v7a/usr/local/lib/libmpv.so    app/build/outputs/apk/release/lib/armeabi-v7a
+cp ../../prefix/x86/usr/local/lib/libmpv.so            app/build/outputs/apk/release/lib/x86
+cp ../../prefix/x86_64/usr/local/lib/libmpv.so         app/build/outputs/apk/release/lib/x86_64
 
-cd ../..
+cd app/build/outputs/apk/release
 
-mkdir -p temp/lib/arm64-v8a
-mkdir -p temp/lib/armeabi-v7a
-mkdir -p temp/lib/x86
-mkdir -p temp/lib/x86_64
-
-cp prefix/arm64-v8a/usr/local/lib/*.so temp/lib/arm64-v8a/
-cp prefix/armeabi-v7a/usr/local/lib/*.so temp/lib/armeabi-v7a/
-cp prefix/x86/usr/local/lib/*.so temp/lib/x86/
-cp prefix/x86_64/usr/local/lib/*.so temp/lib/x86_64/
-
-cd temp
-
-FIXED_TIME="2025-01-01 00:00:00"
-
-find "lib" -type d -exec touch -d "$FIXED_TIME" {} +
-find "lib/arm64-v8a" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-find "lib/armeabi-v7a" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-find "lib/x86" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-find "lib/x86_64" -type f -name "*.so" -exec touch -d "$FIXED_TIME" {} +
-
-md5sum lib/arm64-v8a/*.so
-md5sum lib/armeabi-v7a/*.so
-md5sum lib/x86/*.so
-md5sum lib/x86_64/*.so
-
-find lib/arm64-v8a -type f | sort | zip -r -X ../full-arm64-v8a.jar -@
-find lib/armeabi-v7a -type f | sort | zip -r -X ../full-armeabi-v7a.jar -@
-find lib/x86 -type f | sort | zip -r -X ../full-x86.jar -@
-find lib/x86_64 -type f | sort | zip -r -X ../full-x86_64.jar -@
-
-cd ../
-
-pwd
+zip -r full-arm64-v8a.jar      lib/arm64-v8a/*.so
+zip -r full-armeabi-v7a.jar    lib/armeabi-v7a/*.so
+zip -r full-x86.jar            lib/x86/*.so
+zip -r full-x86_64.jar         lib/x86_64/*.so
 
 md5sum *.jar

--- a/buildscripts/bundle_full.sh
+++ b/buildscripts/bundle_full.sh
@@ -50,3 +50,8 @@ zip -r full-x86.jar            lib/x86/*.so
 zip -r full-x86_64.jar         lib/x86_64/*.so
 
 md5sum *.jar
+
+cd ../../../../../../..
+
+mkdir -p artifacts/full
+cp deps/media-kit-android-helper/app/build/outputs/apk/release/full-*.jar artifacts/full/


### PR DESCRIPTION
Hi all,

In the latest release v1.1.7, the lib has no `full` and `encoders-gpl` artifacts. Our app depends on the `full` artifacts with new 16 KB support. Therefore, we decided to create this PR to re-enable these two artifacts.

We already compiled and create a [release](https://github.com/hienXspecter/libmpv-android-video-build/releases/tag/v1.1.7) on our own to test if it works in our app. Fortunately, it works.

We hosted custom media-kit to get the [full](https://github.com/XSPECTER-GmbH/media-kit-full-build/blob/a47cbf219d147c009b753983979c45af9bc5d649/libs/android/media_kit_libs_android_video/android/build.gradle#L61) artifact for Android, iOS and MacOS.

In the `bundle_full.sh` and `bundle_encoders-gpl.sh`, we just follow what you did in the `bundle_default.sh`. @alexmercerind Please review the PR and create a new release with `full` artifact.

Thank you in advance!