### PR TITLE
Get encoders-gpl compiling properly

### DIFF
--- a/buildscripts/bundle_default.sh
+++ b/buildscripts/bundle_default.sh
@@ -1,9 +1,10 @@
 # --------------------------------------------------
+set -euxo pipefail
 
-if [ ! -f "deps" ]; then
+if [ -d "deps" ]; then
   sudo rm -r deps
 fi
-if [ ! -f "prefix" ]; then
+if [ -d "prefix" ]; then
   sudo rm -r prefix
 fi
 
@@ -12,7 +13,7 @@ fi
 
 # --------------------------------------------------
 
-if [ ! -f "scripts/ffmpeg" ]; then
+if [ -f "scripts/ffmpeg" ]; then
   rm scripts/ffmpeg.sh
 fi
 cp flavors/default.sh scripts/ffmpeg.sh
@@ -23,10 +24,11 @@ cp flavors/default.sh scripts/ffmpeg.sh
 
 zip -r debug-symbols-default.zip prefix/*/lib
 
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
+. ./include/depinfo.sh
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
 
 # --------------------------------------------------
 

--- a/buildscripts/bundle_encoders-gpl.sh
+++ b/buildscripts/bundle_encoders-gpl.sh
@@ -1,20 +1,21 @@
 # --------------------------------------------------
+set -euxo pipefail
 
-if [ ! -f "deps" ]; then
+if [ -d "deps" ]; then
   sudo rm -r deps
 fi
-if [ ! -f "prefix" ]; then
+if [ -d "prefix" ]; then
   sudo rm -r prefix
 fi
 
 export ENCODERS_GPL=1
 
 ./download.sh
-./patch.sh
+./patch-encoders-gpl.sh
 
 # --------------------------------------------------
 
-if [ ! -f "scripts/ffmpeg" ]; then
+if [ -f "scripts/ffmpeg" ]; then
   rm scripts/ffmpeg.sh
 fi
 cp flavors/encoders-gpl.sh scripts/ffmpeg.sh
@@ -25,10 +26,11 @@ cp flavors/encoders-gpl.sh scripts/ffmpeg.sh
 
 zip -r debug-symbols-encoders-gpl.zip prefix/*/lib
 
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
+. ./include/depinfo.sh
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
 
 # --------------------------------------------------
 

--- a/buildscripts/bundle_full.sh
+++ b/buildscripts/bundle_full.sh
@@ -1,9 +1,10 @@
 # --------------------------------------------------
+set -euxo pipefail
 
-if [ ! -f "deps" ]; then
+if [ -d "deps" ]; then
   sudo rm -r deps
 fi
-if [ ! -f "prefix" ]; then
+if [ -d "prefix" ]; then
   sudo rm -r prefix
 fi
 
@@ -12,7 +13,7 @@ fi
 
 # --------------------------------------------------
 
-if [ ! -f "scripts/ffmpeg" ]; then
+if [ -f "scripts/ffmpeg" ]; then
   rm scripts/ffmpeg.sh
 fi
 cp flavors/full.sh scripts/ffmpeg.sh
@@ -23,10 +24,11 @@ cp flavors/full.sh scripts/ffmpeg.sh
 
 zip -r debug-symbols-full.zip prefix/*/lib
 
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
-./sdk/android-sdk-linux/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
+. ./include/depinfo.sh
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/arm64-v8a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/armeabi-v7a/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86/usr/local/lib/libmpv.so
+./sdk/android-sdk-linux/ndk/$v_ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all prefix/x86_64/usr/local/lib/libmpv.so
 
 # --------------------------------------------------
 

--- a/buildscripts/flavors/default.sh
+++ b/buildscripts/flavors/default.sh
@@ -24,7 +24,7 @@ cpuflags=
 [[ "$ndk_triple" == "arm"* ]] && cpuflags="$cpuflags -mfpu=neon -mcpu=cortex-a8"
 
 ../configure \
-	--target-os=android --enable-cross-compile --cross-prefix=$ndk_triple- --ar=$AR --cc=$CC --ranlib=$RANLIB \
+	--target-os=android --enable-cross-compile --cross-prefix=$ndk_triple- --ar=$AR --cc=$CC --nm=llvm-nm --ranlib=$RANLIB \
 	--arch=${ndk_triple%%-*} --cpu=$cpu --pkg-config=pkg-config \
 	--extra-cflags="-I$prefix_dir/include $cpuflags" --extra-ldflags="-L$prefix_dir/lib" \
 	\

--- a/buildscripts/flavors/encoders-gpl.sh
+++ b/buildscripts/flavors/encoders-gpl.sh
@@ -24,7 +24,7 @@ cpuflags=
 [[ "$ndk_triple" == "arm"* ]] && cpuflags="$cpuflags -mfpu=neon -mcpu=cortex-a8"
 
 ../configure \
-	--target-os=android --enable-cross-compile --cross-prefix=$ndk_triple- --ar=$AR --cc=$CC --ranlib=$RANLIB \
+	--target-os=android --enable-cross-compile --cross-prefix=$ndk_triple- --ar=$AR --cc=$CC --nm=llvm-nm --ranlib=$RANLIB \
 	--arch=${ndk_triple%%-*} --cpu=$cpu --pkg-config=pkg-config \
 	--extra-cflags="-I$prefix_dir/include $cpuflags" --extra-ldflags="-L$prefix_dir/lib" \
 	--pkg-config-flags="--static" \
@@ -40,8 +40,6 @@ cpuflags=
 	\
 	--enable-decoders \
 	--enable-encoders \
-	--enable-libvorbis \
-	--enable-libvpx \
 	--enable-gpl \
 	--enable-libx264 \
 	--enable-muxers \

--- a/buildscripts/flavors/full.sh
+++ b/buildscripts/flavors/full.sh
@@ -24,7 +24,7 @@ cpuflags=
 [[ "$ndk_triple" == "arm"* ]] && cpuflags="$cpuflags -mfpu=neon -mcpu=cortex-a8"
 
 ../configure \
-	--target-os=android --enable-cross-compile --cross-prefix=$ndk_triple- --ar=$AR --cc=$CC --ranlib=$RANLIB \
+	--target-os=android --enable-cross-compile --cross-prefix=$ndk_triple- --ar=$AR --cc=$CC --nm=llvm-nm --ranlib=$RANLIB \
 	--arch=${ndk_triple%%-*} --cpu=$cpu --pkg-config=pkg-config \
 	--extra-cflags="-I$prefix_dir/include $cpuflags" --extra-ldflags="-L$prefix_dir/lib" \
 	\

--- a/buildscripts/include/depinfo.sh
+++ b/buildscripts/include/depinfo.sh
@@ -26,7 +26,7 @@ v_libvpx=1.13
 dep_mbedtls=()
 dep_dav1d=()
 dep_libvorbis=(libogg)
-if [ -n "$ENCODERS_GPL" ]; then
+if [ -n "${ENCODERS_GPL+x}" ]; then
 	dep_ffmpeg=(mbedtls dav1d libxml2 libvorbis libvpx libx264)
 else
 	dep_ffmpeg=(mbedtls dav1d libxml2)
@@ -37,7 +37,7 @@ dep_harfbuzz=()
 dep_libass=(freetype fribidi harfbuzz)
 dep_lua=()
 dep_shaderc=()
-if [ -n "$ENCODERS_GPL" ]; then
+if [ -n "${ENCODERS_GPL+x}" ]; then
 	dep_mpv=(ffmpeg libass fftools_ffi)
 else
 	dep_mpv=(ffmpeg libass)

--- a/buildscripts/scripts/libogg.build
+++ b/buildscripts/scripts/libogg.build
@@ -10,6 +10,9 @@ p = mod.add_project('configure',
         '--disable-shared',
         '--enable-static',
     ],
+    cross_configure_options : [
+        '--host=@0@-linux-@1@'.format(host_machine.cpu_family(), host_machine.system())
+    ],
     verbose: true,
 )
 

--- a/buildscripts/scripts/libvorbis.build
+++ b/buildscripts/scripts/libvorbis.build
@@ -10,6 +10,9 @@ p = mod.add_project('configure',
         '--enable-static',
         '--disable-shared',
     ],
+    cross_configure_options : [
+        '--host=@0@-linux-@1@'.format(host_machine.cpu_family(), host_machine.system())
+    ],
     verbose: true,
 )
 

--- a/buildscripts/scripts/libx264.build
+++ b/buildscripts/scripts/libx264.build
@@ -19,6 +19,9 @@ endif
 
 p = mod.add_project('configure',
     configure_options : configure_options,
+    cross_configure_options : [
+        '--host=@0@-linux-@1@'.format(host_machine.cpu_family(), host_machine.system())
+    ],
     verbose: true
 )
 

--- a/buildscripts/scripts/libx264.sh
+++ b/buildscripts/scripts/libx264.sh
@@ -20,7 +20,9 @@ unset CC CXX # meson wants these unset
 
 mkdir $build
 
-meson setup $build --cross-file "$prefix_dir"/crossfile.txt --prefix="$prefix_dir"
+# Stripping breaks the asm ELF metadata within libx264.a
+# We strip at the end anyway
+STRIP="" meson setup $build --cross-file "$prefix_dir"/crossfile.txt --prefix="$prefix_dir"
 
 meson compile -C $build libx264
 meson install -C $build


### PR DESCRIPTION
- Run bundle scripts with safe bash options
  - Cleanup some bashisms
- Use downloaded ndk to strip
- Fix assembler ELFs in libx264
- Fix wrong nm used
- Fix wrong patches applied for encoders-gpl
- Fix cross-compile $HOST on libogg, libvorbis, libx264